### PR TITLE
Make library creation more java friendly

### DIFF
--- a/src/main/scala/com/datasonnet/DS.scala
+++ b/src/main/scala/com/datasonnet/DS.scala
@@ -37,14 +37,15 @@ import ujson.Value
 
 import scala.collection.mutable
 import scala.util.Random
+import scala.jdk.CollectionConverters._
 
 object DSLowercase extends Library {
 
   override def namespace() = "ds"
 
-  override def libsonnets(): Set[String] = Set("util")
+  override def libsonnets(): java.util.Set[String] = Set("util").asJava
 
-  override def functions(dataFormats: DataFormatService, header: Header): Map[String, Val.Func] = Map(
+  override def functions(dataFormats: DataFormatService, header: Header): java.util.Map[String, Val.Func] = Map(
     builtin("contains", "container", "value") {
       (_, _, container: Val, value: Val) =>
         container match {
@@ -757,9 +758,9 @@ object DSLowercase extends Library {
           case _ => first
         }
     }
-  )
+  ).asJava
 
-  override def modules(dataFormats: DataFormatService, header: Header): Map[String, Val.Obj] = Map(
+  override def modules(dataFormats: DataFormatService, header: Header): java.util.Map[String, Val.Obj] = Map(
     "datetime" -> moduleFrom(
       builtin0("now") { (vals, ev, fs) => ZonedDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME) },
 
@@ -2187,7 +2188,7 @@ object DSLowercase extends Library {
           }
       }
     )
-  )
+  ).asJava
 
   def read(dataFormats: DataFormatService, data: String, mimeType: String, params: Val.Obj, ev: EvalScope): Val = {
     val Array(supert, subt) = mimeType.split("/", 2)
@@ -2568,12 +2569,12 @@ object ValOrdering extends Ordering[Val] {
 object DSUppercase extends Library {
   override def namespace() = "DS"
 
-  override def libsonnets(): Set[String] = Set("util")
+  override def libsonnets(): java.util.Set[String] = Set("util").asJava
 
   // no root functions in the old version
-  override def functions(dataFormats: DataFormatService, header: Header): Map[String, Val.Func] = Map()
+  override def functions(dataFormats: DataFormatService, header: Header): java.util.Map[String, Val.Func] = Map().asJava
 
-  override def modules(dataFormats: DataFormatService, header: Header): Map[String, Val.Obj] = Map(
+  override def modules(dataFormats: DataFormatService, header: Header): java.util.Map[String, Val.Obj] = Map(
     "ZonedDateTime" -> moduleFrom(
       builtin0("now") { (vals, ev, fs) => Instant.now().toString() },
 
@@ -2780,5 +2781,5 @@ object DSUppercase extends Library {
         java.net.URLDecoder.decode(data, encoding)
       },
     )
-  )
+  ).asJava
 }

--- a/src/main/scala/com/datasonnet/spi/Library.scala
+++ b/src/main/scala/com/datasonnet/spi/Library.scala
@@ -20,11 +20,13 @@ import com.datasonnet.Mapper
 import com.datasonnet.header.Header
 import fastparse.Parsed
 import sjsonnet.Expr.Member.Visibility
+import sjsonnet.Expr.Params
 import sjsonnet.Val.Obj
 import sjsonnet.{Evaluator, Expr, Val}
 
 import scala.collection.mutable
 import scala.io.Source
+import scala.jdk.CollectionConverters._
 
 object Library {
   val emptyObj = new Val.Obj(mutable.HashMap.empty[String, Obj.Member], _ => (), None)
@@ -35,11 +37,11 @@ object Library {
 abstract class Library {
   def namespace(): String
 
-  def functions(dataFormats: DataFormatService, header: Header): Map[String, Val.Func]
+  def functions(dataFormats: DataFormatService, header: Header): java.util.Map[String, Val.Func]
 
-  def modules(dataFormats: DataFormatService, header: Header): Map[String, Val.Obj]
+  def modules(dataFormats: DataFormatService, header: Header): java.util.Map[String, Val.Obj]
 
-  def libsonnets(): Set[String]
+  def libsonnets(): java.util.Set[String]
 
   protected def moduleFrom(functions: (String, Val.Func)*): Val.Obj = new Val.Obj(
     mutable.LinkedHashMap[String, Val.Obj.Member](
@@ -50,6 +52,16 @@ abstract class Library {
     None
   )
 
+  protected def makeSimpleFunc(params: java.util.List[String], eval: java.util.function.Function[java.util.List[Val], Val]): Val.Func = {
+    val paramData = params.asScala.zipWithIndex.map{case (k,  i) => (k, None, i)}.toArray
+    val paramIndices = params.asScala.indices
+    Val.Func(
+      None,
+      Params(paramData),
+      {(scope, thisFile, ev, fs, outerOffset) => eval.apply(paramIndices.map(i => scope.bindings(i).get.force).asJava) }
+    )
+  }
+
   def makeLib(dataFormatService: DataFormatService,
               header: Header,
               evaluator: Evaluator,
@@ -57,13 +69,13 @@ abstract class Library {
              ): Map[String, Val.Obj] = Map(
     namespace() -> new Val.Obj(
       mutable.LinkedHashMap()
-        ++ functions(dataFormatService, header).map {
+        ++ functions(dataFormatService, header).asScala.map {
         case (key, value) => (key, memberOf(value))
       }
-        ++ modules(dataFormatService, header).map {
+        ++ modules(dataFormatService, header).asScala.map {
         case (key, value) => (key, memberOf(value))
       }
-        ++ libsonnets().map {
+        ++ libsonnets().asScala.map {
         key => (key, memberOf(resolveLibsonnet(key, evaluator, cache)))
       }.toMap,
       _ => (),


### PR DESCRIPTION
This makes DataSonnet Library creation more java friendly with some small modifications to the contract to use java collections instead of scala ones, plus the creation of a utility function to abstract creation of scala functions that do not need to use the eval scope or file scope, the most common kind of simple function. A similar function should be added later that does pass the eval scope and file scope, since it is very common for DataSonnet code to use higher order functions. That may entail a "function calling wrapper" so it is possible to continue to use pure java.

An extremely simple all-Java library implementation could then be

```java
package com.datasonnet;

import com.datasonnet.header.Header;
import com.datasonnet.spi.DataFormatService;
import com.datasonnet.spi.Library;
import scala.Option;
import sjsonnet.Val;

import java.util.Collections;
import java.util.Map;
import java.util.Set;

public class ExampleLibrary extends Library {
    @Override
    public String namespace() {
        return "example";
    }

    @Override
    public Map<String, Val.Func> functions(DataFormatService dataFormats, Header header) {
        return Collections.singletonMap("echo", makeSimpleFunc(Collections.singletonList("value"), vs -> vs.get(0)));
    }

    @Override
    public Map<String, Val.Obj> modules(DataFormatService dataFormats, Header header) {
        return Collections.emptyMap();
    }

    @Override
    public Set<String> libsonnets() {
        return Collections.emptySet();
    }
}
```