### PR TITLE
Add support for comments in headers

### DIFF
--- a/src/main/java/com/datasonnet/header/Header.java
+++ b/src/main/java/com/datasonnet/header/Header.java
@@ -40,6 +40,7 @@ import java.util.regex.Pattern;
 
 public class Header {
     public static final String DATASONNET_HEADER = "/** DataSonnet";
+    public static final String COMMENT_PREFIX = "#";
     public static final Pattern VERSION_LINE = Pattern.compile("^version *= *(?<version>[a-zA-Z0-9.+-]+) *(\\r?\\n|$)");
     public static final String DATASONNET_DEFAULT_PREFIX = "default ";
     public static final String DATASONNET_INPUT = "input";
@@ -250,6 +251,7 @@ public class Header {
         List<MediaType> dataformat = new ArrayList<>(4);
 
         for (String line : headerSection.split("\\r?\\n")) {
+            line = line.trim();  // we never care about leading or trailing whitespace
             try {
                 if (line.startsWith(DATASONNET_PRESERVE_ORDER)) {
                     String[] tokens = line.split("=", 2);
@@ -292,8 +294,8 @@ public class Header {
                     String[] tokens = line.split(" ", 2);
                     MediaType toAdd = MediaType.valueOf(tokens[1]);
                     dataformat.add(toAdd);
-                } else if (line.trim().isEmpty()) {
-                    // this is allowed, and we pass
+                } else if (line.isEmpty() || line.startsWith(COMMENT_PREFIX)) {
+                    // deliberately do nothing
                 } else {
                     throw new HeaderParseException("Unable to parse header line: " + line);
                 }

--- a/src/main/java/com/datasonnet/header/Header.java
+++ b/src/main/java/com/datasonnet/header/Header.java
@@ -40,7 +40,7 @@ import java.util.regex.Pattern;
 
 public class Header {
     public static final String DATASONNET_HEADER = "/** DataSonnet";
-    public static final String COMMENT_PREFIX = "#";
+    public static final String COMMENT_PREFIX = "//";
     public static final Pattern VERSION_LINE = Pattern.compile("^version *= *(?<version>[a-zA-Z0-9.+-]+) *(\\r?\\n|$)");
     public static final String DATASONNET_DEFAULT_PREFIX = "default ";
     public static final String DATASONNET_INPUT = "input";

--- a/src/test/java/com/datasonnet/HeaderTest.java
+++ b/src/test/java/com/datasonnet/HeaderTest.java
@@ -38,11 +38,13 @@ public class HeaderTest {
     String headerStr = "/** DataSonnet\n" +
             "version=2.0\n" +
             "preserveOrder=false\n" +
+            "  \n" +
+            "# comment\n" +
             "input payload application/xml;namespace-separator=\":\";text-value-key=__text\n" +
             "input * application/xml;text-value-key=__text\n" +
             "input myvar application/csv;separator=|\n" +
             "dataformat application/vnd.ms-excel;payload.param=xyz\n" +
-            "output application/csv;ds.csv.quote=\"\"\"\n" +
+            "  output application/csv;ds.csv.quote=\"\"\"\n" +
             "*/\n" +
             "[\n" +
             "    {\n" +

--- a/src/test/java/com/datasonnet/HeaderTest.java
+++ b/src/test/java/com/datasonnet/HeaderTest.java
@@ -39,7 +39,7 @@ public class HeaderTest {
             "version=2.0\n" +
             "preserveOrder=false\n" +
             "  \n" +
-            "# comment\n" +
+            "// comment\n" +
             "input payload application/xml;namespace-separator=\":\";text-value-key=__text\n" +
             "input * application/xml;text-value-key=__text\n" +
             "input myvar application/csv;separator=|\n" +


### PR DESCRIPTION
This PR changes it so that lines in the header starting with `//` (not counting initial whitespace) are treated as comments and ignored (like empty lines also are). No other placement for comments is supported.

Resolves #66 