### PR TITLE
Add function for flattening XML content

### DIFF
--- a/src/main/scala/com/datasonnet/DS.scala
+++ b/src/main/scala/com/datasonnet/DS.scala
@@ -374,37 +374,6 @@ object DSLowercase extends Library {
         reg.r.replaceAllIn(str, replacement)
     },
 
-    builtinWithDefaults("flattenXmlContents", "element" -> None, "namespaces" -> Some(Expr.Null(0))) {
-      (args, ev) =>
-        val element = args("element").cast[Val.Obj]
-        val namespaces = if (args("namespaces") == Val.Null) {
-          Library.emptyObj
-        } else {
-          args("namespaces").cast[Val.Obj]
-        }
-
-        val wrapperName = "a"
-        val wrapperStop = s"</$wrapperName>"
-
-        val wrapperProperties = scala.collection.mutable.Map[String, Val.Obj.Member]()
-        wrapperProperties += ("a" -> Val.Obj.Member(add = false, Visibility.Normal, (_, _, _, _) => element))
-        val wrapped = new Val.Obj(wrapperProperties, _ => (), None)
-
-        val xmlProperties = scala.collection.mutable.Map[String, Val.Obj.Member]()
-        xmlProperties += ("OmitXmlDeclaration" -> Val.Obj.Member(add = false, Visibility.Normal, (_, _, _, _) => Val.Str("true")))
-        namespaces.foreachVisibleKey((key, _) => {
-          xmlProperties += ("NamespaceDeclarations." + key ->
-            Val.Obj.Member(add = false, Visibility.Normal, (_, _, _, _) =>
-              namespaces.value(key, -1)(new FileScope(null, Map.empty), ev)))
-        })
-
-        val properties = new Val.Obj(xmlProperties, _ => (), None)
-
-        val written = write(dataFormats, wrapped, "application/xml", properties, ev)
-
-        written.substring(written.indexOf(">") + 1, written.length - wrapperStop.length)
-    },
-
     // moved from dataformats
     builtinWithDefaults("read",
       "data" -> None,
@@ -792,6 +761,38 @@ object DSLowercase extends Library {
   ).asJava
 
   override def modules(dataFormats: DataFormatService, header: Header): java.util.Map[String, Val.Obj] = Map(
+    "xml" -> moduleFrom(
+      builtinWithDefaults("flattenContents", "element" -> None, "namespaces" -> Some(Expr.Null(0))) {
+        (args, ev) =>
+          val element = args("element").cast[Val.Obj]
+          val namespaces = if (args("namespaces") == Val.Null) {
+            Library.emptyObj
+          } else {
+            args("namespaces").cast[Val.Obj]
+          }
+
+          val wrapperName = "a"
+          val wrapperStop = s"</$wrapperName>"
+
+          val wrapperProperties = scala.collection.mutable.Map[String, Val.Obj.Member]()
+          wrapperProperties += ("a" -> Val.Obj.Member(add = false, Visibility.Normal, (_, _, _, _) => element))
+          val wrapped = new Val.Obj(wrapperProperties, _ => (), None)
+
+          val xmlProperties = scala.collection.mutable.Map[String, Val.Obj.Member]()
+          xmlProperties += ("OmitXmlDeclaration" -> Val.Obj.Member(add = false, Visibility.Normal, (_, _, _, _) => Val.Str("true")))
+          namespaces.foreachVisibleKey((key, _) => {
+            xmlProperties += ("NamespaceDeclarations." + key ->
+              Val.Obj.Member(add = false, Visibility.Normal, (_, _, _, _) =>
+                namespaces.value(key, -1)(new FileScope(null, Map.empty), ev)))
+          })
+
+          val properties = new Val.Obj(xmlProperties, _ => (), None)
+
+          val written = write(dataFormats, wrapped, "application/xml", properties, ev)
+
+          written.substring(written.indexOf(">") + 1, written.length - wrapperStop.length)
+      },
+    ),
     "datetime" -> moduleFrom(
       builtin0("now") { (vals, ev, fs) => ZonedDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME) },
 

--- a/src/test/java/com/datasonnet/XMLPropertyTest.java
+++ b/src/test/java/com/datasonnet/XMLPropertyTest.java
@@ -71,5 +71,4 @@ public class XMLPropertyTest {
             fail("Unable to convert to xml: " + json);
         }
     }
-
 }

--- a/src/test/java/com/datasonnet/XMLWriterTest.java
+++ b/src/test/java/com/datasonnet/XMLWriterTest.java
@@ -219,7 +219,7 @@ public class XMLWriterTest {
         String xmlData = TestResourceReader.readFileAsString("xmlMixedContent.xml");
         String expected = TestResourceReader.readFileAsString("xmlMixedContent.txt");
 
-        Mapper mapper = new Mapper("ds.flattenXmlContents(payload.letter)");
+        Mapper mapper = new Mapper("ds.xml.flattenContents(payload.letter)");
 
         String mapped = mapper.transform(new DefaultDocument<>(xmlData, MediaType.valueOf(MediaTypes.APPLICATION_XML_VALUE)), Collections.emptyMap(), MediaTypes.TEXT_PLAIN).getContent();
 
@@ -231,7 +231,7 @@ public class XMLWriterTest {
         String xmlData = TestResourceReader.readFileAsString("xmlMixedContentNamespaces.xml");
         String expected = TestResourceReader.readFileAsString("xmlMixedContent.txt");
 
-        Mapper mapper = new Mapper("ds.flattenXmlContents(payload[\"ns:letter\"], {\"$\": \"https://example.com\"})");
+        Mapper mapper = new Mapper("ds.xml.flattenContents(payload[\"ns:letter\"], {\"$\": \"https://example.com\"})");
 
         String mapped = mapper.transform(new DefaultDocument<>(xmlData, MediaType.valueOf(MediaTypes.APPLICATION_XML_VALUE)), Collections.emptyMap(), MediaTypes.TEXT_PLAIN).getContent();
 

--- a/src/test/java/com/datasonnet/XMLWriterTest.java
+++ b/src/test/java/com/datasonnet/XMLWriterTest.java
@@ -17,6 +17,7 @@ package com.datasonnet;
  */
 
 import com.datasonnet.document.DefaultDocument;
+import com.datasonnet.document.MediaType;
 import com.datasonnet.document.MediaTypes;
 import com.datasonnet.util.TestResourceReader;
 import org.junit.jupiter.api.Test;
@@ -211,6 +212,33 @@ public class XMLWriterTest {
 
         assertTrue(mappedXml.startsWith("<?xml"));
     }
+
+    // TODO add version using namespaces
+    @Test
+    void testFlattenMixedContent() throws Exception {
+        String xmlData = TestResourceReader.readFileAsString("xmlMixedContent.xml");
+        String expected = TestResourceReader.readFileAsString("xmlMixedContent.txt");
+
+        Mapper mapper = new Mapper("ds.flattenXmlContents(payload.letter)");
+
+        String mapped = mapper.transform(new DefaultDocument<>(xmlData, MediaType.valueOf(MediaTypes.APPLICATION_XML_VALUE)), Collections.emptyMap(), MediaTypes.TEXT_PLAIN).getContent();
+
+        assertEquals(expected, mapped);
+    }
+
+    @Test
+    void testFlattenMixedContentWithNamespaces() throws Exception {
+        String xmlData = TestResourceReader.readFileAsString("xmlMixedContentNamespaces.xml");
+        String expected = TestResourceReader.readFileAsString("xmlMixedContent.txt");
+
+        Mapper mapper = new Mapper("ds.flattenXmlContents(payload[\"ns:letter\"], {\"$\": \"https://example.com\"})");
+
+        String mapped = mapper.transform(new DefaultDocument<>(xmlData, MediaType.valueOf(MediaTypes.APPLICATION_XML_VALUE)), Collections.emptyMap(), MediaTypes.TEXT_PLAIN).getContent();
+
+        assertEquals(expected, mapped, "Expected " + expected + " but got " + mapped);
+    }
+
+
 
     @Test
     void testXMLRoot() throws Exception {

--- a/src/test/java/com/datasonnet/util/TestResourceReader.java
+++ b/src/test/java/com/datasonnet/util/TestResourceReader.java
@@ -28,11 +28,6 @@ public class TestResourceReader {
     public static String readFileAsString(String filePath) throws URISyntaxException, IOException {
         Path path = Paths.get(TestResourceReader.class.getClassLoader()
                 .getResource(filePath).toURI());
-
-        Stream<String> lines = Files.lines(path);
-        String data = lines.collect(Collectors.joining("\n"));
-        lines.close();
-
-        return data;
+        return new String(Files.readAllBytes(path));
     }
 }

--- a/src/test/resources/xmlMixedContent.txt
+++ b/src/test/resources/xmlMixedContent.txt
@@ -1,0 +1,5 @@
+
+    Dear Mr. <name>John Smith</name>.
+    Your order <orderid>1032</orderid>
+    will be shipped on <shipdate>2001-07-13</shipdate>.
+    <![CDATA[PS Happy Holidays!]]><name>Sam Smith</name>

--- a/src/test/resources/xmlMixedContentNamespaces.xml
+++ b/src/test/resources/xmlMixedContentNamespaces.xml
@@ -1,0 +1,8 @@
+<?xml version="1.1" encoding="UTF-8" standalone="yes"?>
+<ns:letter xmlns:ns="https://example.com">
+    Dear Mr. <ns:name>John Smith</ns:name>.
+    Your order <ns:orderid>1032</ns:orderid>
+    will be shipped on <ns:shipdate>2001-07-13</ns:shipdate>.
+    <![CDATA[PS Happy Holidays!]]><ns:name>Sam Smith</ns:name>
+</ns:letter>
+


### PR DESCRIPTION
This makes it easy for a user receiving XML content to turn some part (such as mixed content element containing an HTML comment) into a string that can then be put into output.

Resolves #57 