### PR TITLE
bugfix/java mediatype

### DIFF
--- a/src/main/java/com/datasonnet/plugins/DefaultJavaFormatPlugin.java
+++ b/src/main/java/com/datasonnet/plugins/DefaultJavaFormatPlugin.java
@@ -103,7 +103,7 @@ public class DefaultJavaFormatPlugin extends BaseJacksonDataFormatPlugin {
     @Override
     public <T> Document<T> write(Value input, MediaType mediaType, Class<T> targetType) throws PluginException {
         T converted = writeValue(input, mediaType, targetType);
-        return new DefaultDocument<>(converted);
+        return new DefaultDocument<>(converted, mediaType);
     }
 
     @Nullable

--- a/src/test/java/com/datasonnet/CSVWriterTest.java
+++ b/src/test/java/com/datasonnet/CSVWriterTest.java
@@ -41,9 +41,11 @@ public class CSVWriterTest {
         Mapper mapper = new Mapper("payload");
 
 
-        String mapped = mapper.transform(data, Collections.emptyMap(), MediaTypes.APPLICATION_CSV).getContent();
+        Document<String> mapped = mapper.transform(data, Collections.emptyMap(), MediaTypes.APPLICATION_CSV);
+        assertEquals(MediaTypes.APPLICATION_CSV, mapped.getMediaType());
+
         String expected = TestResourceReader.readFileAsString("writeCSVTest.csv");
-        assertEquals(expected.trim(), mapped.trim());
+        assertEquals(expected.trim(), mapped.getContent().trim());
     }
 
     @Test

--- a/src/test/java/com/datasonnet/JSONWriterTest.java
+++ b/src/test/java/com/datasonnet/JSONWriterTest.java
@@ -1,0 +1,47 @@
+package com.datasonnet;
+
+/*-
+ * Copyright 2019-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.datasonnet.document.DefaultDocument;
+import com.datasonnet.document.Document;
+import com.datasonnet.document.MediaTypes;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JSONWriterTest {
+
+    @Test
+    public void testJSONWriter() {
+
+        Mapper mapper = new Mapper("{ \n" +
+                " str: 'value', \n" +
+                " arr: [1, 2, 3], \n" +
+                " obj: {}, \n" +
+                " num: 9, \n" +
+                " 'null': null \n" +
+                "}");
+
+        Document<String> mapped = mapper.transform(DefaultDocument.NULL_INSTANCE, Collections.emptyMap(), MediaTypes.APPLICATION_JSON);
+        assertEquals(MediaTypes.APPLICATION_JSON, mapped.getMediaType());
+
+        String expected = "{\"str\":\"value\",\"arr\":[1,2,3],\"obj\":{},\"num\":9,\"null\":null}";
+        assertEquals(expected.trim(), mapped.getContent().trim());
+    }
+}

--- a/src/test/java/com/datasonnet/JavaReaderTest.java
+++ b/src/test/java/com/datasonnet/JavaReaderTest.java
@@ -54,7 +54,7 @@ public class JavaReaderTest {
         SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd");
         theGizmo.setDate(df.parse("2020-01-06"));
 
-        Document<Gizmo> data = new DefaultDocument<>(theGizmo);
+        Document<Gizmo> data = new DefaultDocument<>(theGizmo, MediaTypes.APPLICATION_JAVA);
 
         String mapping = TestResourceReader.readFileAsString("readJavaTest.ds");
 
@@ -73,7 +73,7 @@ public class JavaReaderTest {
         obj.setTestField(new JAXBElement<TestField>(new QName("http://com.datasonnet.test", "testField"),
                 TestField.class,
                 testField));
-        Document<WsdlGeneratedObj> data = new DefaultDocument<>(obj);
+        Document<WsdlGeneratedObj> data = new DefaultDocument<>(obj, MediaTypes.APPLICATION_JAVA);
         Mapper mapper = new Mapper("payload");
         Document<String> mapped = mapper.transform(data, new HashMap<>(), MediaTypes.APPLICATION_JSON);
 
@@ -83,7 +83,7 @@ public class JavaReaderTest {
 
     @Test
     void testNullJavaObject() throws Exception {
-        Document<Gizmo> nullObj = new DefaultDocument<>(null);
+        Document<?> nullObj = DefaultDocument.NULL_INSTANCE;
         Mapper mapper = new Mapper("payload == null");
         Document<Boolean> mapped = mapper.transform(nullObj, new HashMap<>(), MediaTypes.APPLICATION_JAVA, Boolean.class);
         assertTrue(mapped.getContent());

--- a/src/test/java/com/datasonnet/JavaWriterTest.java
+++ b/src/test/java/com/datasonnet/JavaWriterTest.java
@@ -52,6 +52,8 @@ public class JavaWriterTest {
 
         Document<Gizmo> mapped = mapper.transform(data, new HashMap<>(), MediaTypes.APPLICATION_JAVA, Gizmo.class);
 
+        assertTrue(MediaTypes.APPLICATION_JAVA.equalsTypeAndSubtype(mapped.getMediaType()));
+
         Object result = mapped.getContent();
         assertTrue(result instanceof Gizmo);
 

--- a/src/test/java/com/datasonnet/XMLWriterTest.java
+++ b/src/test/java/com/datasonnet/XMLWriterTest.java
@@ -17,6 +17,7 @@ package com.datasonnet;
  */
 
 import com.datasonnet.document.DefaultDocument;
+import com.datasonnet.document.Document;
 import com.datasonnet.document.MediaType;
 import com.datasonnet.document.MediaTypes;
 import com.datasonnet.util.TestResourceReader;
@@ -87,9 +88,9 @@ public class XMLWriterTest {
 
         Mapper mapper = new Mapper(datasonnet);
 
-        String mappedXml = mapper.transform(new DefaultDocument<>(jsonData, MediaTypes.APPLICATION_JSON), Collections.emptyMap(), MediaTypes.APPLICATION_XML).getContent();
-
-        assertThat(mappedXml, CompareMatcher.isSimilarTo(expectedXml).ignoreWhitespace());
+        Document<String> mappedXml = mapper.transform(new DefaultDocument<>(jsonData, MediaTypes.APPLICATION_JSON), Collections.emptyMap(), MediaTypes.APPLICATION_XML);
+        assertEquals(MediaTypes.APPLICATION_XML, mappedXml.getMediaType());
+        assertThat(mappedXml.getContent(), CompareMatcher.isSimilarTo(expectedXml).ignoreWhitespace());
     }
 
     @Test

--- a/src/test/java/com/datasonnet/XMLWriterTest.java
+++ b/src/test/java/com/datasonnet/XMLWriterTest.java
@@ -116,7 +116,7 @@ public class XMLWriterTest {
         String expectedXml = TestResourceReader.readFileAsString("writeXMLEscapedTest.xml");
 
         Mapper mapper = new Mapper(datasonnet);
-        String mappedXml = mapper.transform(new DefaultDocument<>(null), Collections.emptyMap(), MediaTypes.APPLICATION_XML, String.class).getContent();
+        String mappedXml = mapper.transform(DefaultDocument.NULL_INSTANCE, Collections.emptyMap(), MediaTypes.APPLICATION_XML, String.class).getContent();
 
         assertThat(mappedXml, CompareMatcher.isSimilarTo(expectedXml).ignoreWhitespace());
     }


### PR DESCRIPTION
 fixes 'unknown' media type from Java plugin

The DefaultDocument class changed from defaulting to Java for media type to using unknown, the Java plugin was not updated accordingly

