### PR TITLE
Use UTC  when parsing date.

### DIFF
--- a/src/test/java/com/datasonnet/JavaReaderTest.java
+++ b/src/test/java/com/datasonnet/JavaReaderTest.java
@@ -33,6 +33,7 @@ import javax.xml.namespace.QName;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.TimeZone;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -52,6 +53,7 @@ public class JavaReaderTest {
         theGizmo.setManufacturer(manufacturer);
 
         SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd");
+        df.setTimeZone(TimeZone.getTimeZone("UTC"));
         theGizmo.setDate(df.parse("2020-01-06"));
 
         Document<Gizmo> data = new DefaultDocument<>(theGizmo, MediaTypes.APPLICATION_JAVA);


### PR DESCRIPTION
Specify timezone to parse date in a test.
```java.lang.AssertionError: 
pojoDate
Expected: 2020-01-06
     got: 2020-01-05

        at com.datasonnet.JavaReaderTest.testJavaReader(JavaReaderTest.java:65)
```