### PR TITLE
tweaks to work with command line

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -570,6 +570,9 @@
         </profile>
         <profile>
             <id>jakarta</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <dependencies>
                 <dependency>
                     <groupId>jakarta.xml.bind</groupId>

--- a/src/main/java/com/datasonnet/commands/Main.java
+++ b/src/main/java/com/datasonnet/commands/Main.java
@@ -41,6 +41,6 @@ public class Main implements Runnable {
     }
 
     static String readFile(File file) throws IOException {
-        return Files.lines(file.toPath()).collect(Collectors.joining());
+        return Files.lines(file.toPath()).collect(Collectors.joining("\n"));
     }
 }

--- a/src/main/java/com/datasonnet/commands/Run.java
+++ b/src/main/java/com/datasonnet/commands/Run.java
@@ -74,7 +74,7 @@ public class Run implements Callable<Void> {
     public Void call() throws Exception {
         Mapper mapper = new Mapper(Main.readFile(datasonnet), combinedArguments().keySet(), imports(), !alreadyWrapped);
         Document<String> result = mapper
-                .transform(new DefaultDocument<>(payload(), MediaTypes.forExtension(suffix(datasonnet)).get()),
+                .transform(new DefaultDocument<>(payload(), MediaTypes.forExtension(suffix(input)).get()),
                         combinedArguments(), MediaType.valueOf(outputType));
         String contents = result.getContent();
         System.out.println(contents);
@@ -83,7 +83,7 @@ public class Run implements Callable<Void> {
     }
 
     private String suffix(File file) {
-        String[] parts = file.getName().split(".");
+        String[] parts = file.getName().split("\\.");
         if (parts.length > 1) {
             return parts[parts.length - 1];
         } else {


### PR DESCRIPTION
Faced a number of small issues running the command line version out of the box
[ERROR] Failed to execute goal net.alchim31.maven:scala-maven-plugin:4.4.0:compile (scala-compile-first) on project datasonnet-mapper: Execution scala-compile-first of goal net.alchim31.maven:scala-maven-plugin:4.4.0:compile failed.: CompileFailed -> [Help 1]
[ERROR]
-- Changed the pom.xml to have jakarta profile activeByDefault fixed the build error (could use command line too of course but I am lazy)
-- When reading the .ds file if the newline is omitted from the .joining() method then the header parsing fails
-- I think the DefaultDocument wants the suffix of the input file not the datasonnet mapping file
-- Escape the "." in the split() regex